### PR TITLE
Updated to rspec 2.10 to avoid a bug under ruby 1.9.3-p194.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ group :development do
   gem "rake"
   gem "bio-bigbio", "> 0.1.3"         # for reading FASTA files in tests
   gem "cucumber", ">= 0"
-  gem "rspec", "~> 2.3.0"
+  gem "rspec", "~> 2.10.0"
   gem "bundler", ">= 1.0.21"
   gem "jeweler"
 end


### PR DESCRIPTION
rspec 2.3 is broken with ruby 1.9.3-p194, per https://github.com/rspec/rspec-core/pull/258. The current version, 2.10, works nicely. This is just a Gemfile update for this issue.
